### PR TITLE
Confusion Matrix Table

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -20,6 +20,7 @@ if __name__ == '__main__':
     parser.add_argument('--full', action='store_true')
     parser.add_argument('--use_beam', action='store_true')
     parser.add_argument('--beam_width', default=10, type=int)
+    parser.add_argument('--confusion', default=False, action="store_true")
     args = parser.parse_args()
 
     model = BaseModel.load(args.model_path).to(args.device)
@@ -48,4 +49,4 @@ if __name__ == '__main__':
     testset = Dataset(settings, Reader(settings, *args.test_path), model.label_encoder)
 
     for task in model.evaluate(testset, trainset).values():
-        task.print_summary(full=args.full)
+        task.print_summary(full=args.full, confusion_matrix=args.confusion)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ numpy==1.14.3
 termcolor==1.1.0
 scikit_learn==0.19.1
 PyYAML==3.13 # make sure to have libyaml-dev bindings for speed
+terminaltables==3.1.0


### PR DESCRIPTION
Hey there,
As discussed, I added a small option (--confusion) to evaluate.py to print out some nice Confusion Table. Here is the kind of output you get 
[output.txt](https://github.com/emanjavacas/pie/files/2708928/output.txt)
This is Github Flavoured tables so you have markdown 


| Expected      | Total Errors | Predictions  | Predicted times |
|---------------|--------------|--------------|-----------------|
| vos1          | 72           | vos          | 71              |
|               |              | vostre       | 1               |
| que4          | 30           | que2         | 17              |
|               |              | que1         | 10              |
|               |              | que3         | 3               |
| le            | 25           | il           | 25              |
| que2          | 24           | que4         | 19              |
|               |              | que3         | 2               |
|               |              | que1         | 2               |
|               |              | coi2         | 1               |
| avoir         | 18           | a3           | 17              |
|               |              | aidier       | 1               |
| que1          | 17           | que4         | 16              |
|               |              | que2         | 1               |
| mie           | 15           | mie1         | 14              |
|               |              | mon1         | 1               |
| il            | 14           | le           | 11              |
|               |              | là           | 2               |
|               |              | i2           | 1               |
| se            | 10           | si           | 8               |
|               |              | soi1         | 2               |
| saint         | 8            | saint1       | 7               |
|               |              | saint-genis  | 1               |
| senefiier     | 7            | signier      | 7               |
| ne2           | 7            | ne1          | 7               |
| cui           | 7            | qui          | 6               |
|               |              | coi1         | 1               |
| en2           | 7            | en1          | 7               |
| ne1           | 7            | ne2          | 7               |
