### PR TITLE
Webapp customization

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,2 +1,3 @@
 flask==1.0.2
 gunicorn==19.9.0
+typing==3.6.6

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1,0 +1,110 @@
+"""
+    For more information about how to run the webapp, go check app.py in
+    the root directory.
+    This module is available so that you can enhance or customize your app
+    by changing its tokenizer for example
+
+"""
+from os import getenv
+from typing import Iterator, List, Tuple, Callable, Iterable
+from flask import Flask, request, Response, stream_with_context, current_app
+
+from pie.tagger import Tagger, simple_tokenizer
+from pie.utils import chunks, model_spec
+
+model_file = getenv("PIE_MODEL")
+BATCH = int(getenv("PIE_BATCH", 3))
+DEVICE = getenv("PIE_DEVICE", "cpu")
+
+
+Tokenizer = Callable[[str, bool], Iterable[List[str]]]
+
+
+class DataIterator:
+    def __init__(self, tokenizer: Tokenizer = None):
+        """ Iterator used to parse the text and returns bits to tag
+
+        :param tokenizer: Tokenizer
+        """
+        self.tokenizer = tokenizer or simple_tokenizer
+
+    def __call__(self, data: str, lower: bool = False) -> Iterable[Tuple[List[str], int]]:
+        """ Default iter data takes a text, an option to make lower
+        and yield lists of words along with the length of the list
+
+        :param data: A plain text
+        :param lower: Whether or not to lower the text
+        :yields: (Sentence as a list of word, Size of the sentence)
+        """
+        for sentence in self.tokenizer(data, lower=lower):
+            yield sentence, len(sentence)
+
+
+def bind(app: Flask = None, device: str = None, batch_size: int=None,
+         tokenizer: Tokenizer = None, allow_origin: str = None) -> Flask:
+    """ Binds default value
+
+    :param app: Flask app to bind with the tagger
+    :param device: Device to use for PyTorch (Default : cpu)
+    :param batch_size: Size of the batch to treat
+    :param tokenizer: Tokenizer to split text into segments (eg. sentence) and into words
+    :param allow_origin: Value for the http header field Access-Control-Allow-Origin
+    :returns: Application
+    """
+    # Generates or use default values for non completed parameters
+    if not app:
+        app = Flask(__name__)
+    if not device:
+        device = DEVICE
+    if not batch_size:
+        batch_size = BATCH
+    if not allow_origin:
+        allow_origin = '*'
+    if tokenizer:
+        data_iterator = DataIterator(tokenizer)
+    else:
+        data_iterator = DataIterator()
+
+    tagger = Tagger(device=device, batch_size=batch_size)
+
+    for model, tasks in model_spec(model_file):
+        tagger.add_model(model, *tasks)
+
+    @app.route("/", methods=["POST", "GET", "OPTIONS"])
+    def index():
+        def lemmatization_stream() -> Iterator[str]:
+            lower = request.args.get("lower", False)
+            if lower:
+                lower = True
+
+            if request.method == "GET":
+                data = request.args.get("data")
+            else:
+                data = request.form.get("data")
+
+            if not data:
+                yield ""
+
+            header = False
+            for chunk in chunks(data_iterator(data, lower=lower), size=BATCH):
+                sents, lengths = zip(*chunk)
+
+                tagged, tasks = tagger.tag(sents=sents, lengths=lengths)
+                sep = "\t"
+                for sent in tagged:
+                    if not header:
+                        yield sep.join(['token'] + tasks) + '\r\n'
+                        header = True
+                    for token, tags in sent:
+                        yield sep.join([token] + list(tags)) + '\r\n'
+
+        return Response(
+               stream_with_context(lemmatization_stream()),
+               200,
+               headers={
+                'Content-Type': 'text/plain; charset=utf-8',
+                'Access-Control-Allow-Origin': allow_origin
+               }
+        )
+
+    return app


### PR DESCRIPTION
Fix for #12.

`app.py` still remains available but now uses `webapp.bind()` to generate the app.
People willing to customize their tokenizer or add more thing to the app can now do so. An example can be found at https://github.com/chartes/deucalion-model-af with a form added.

I think it would be cool if you like this PR to make a release, so that my Docker Images download the tag instead of the branch :) As well, I did not do it, but maybe it would be interesting for people to have a link to https://github.com/chartes/deucalion-model-af if they want to build their own webservice easily.
