### PR TITLE
Faster precision recall

### DIFF
--- a/pie/models/scorer.py
+++ b/pie/models/scorer.py
@@ -74,17 +74,21 @@ class Scorer(object):
             raise ValueError("Unequal input lengths. Hyps {}, targets {}, tokens {}"
                              .format(len(hyps), len(targets), len(tokens)))
 
-        for pred, true, token in zip(hyps, targets, tokens):
-            if self.label_encoder.preprocessor_fn is not None:
+        if not self.label_encoder.preprocessor_fn:
+            self.preds.extend(hyps)
+            self.trues.extend(targets)
+            self.tokens.extend(tokens)
+        else:
+            for pred, true, token in zip(hyps, targets, tokens):
                 true = self.label_encoder.preprocessor_fn.inverse_transform(true, token)
                 try:
                     pred = self.label_encoder.preprocessor_fn.inverse_transform(
                         pred, token)
                 except:
                     pred = constants.INVALID
-            self.preds.append(pred)
-            self.trues.append(true)
-            self.tokens.append(token)
+                self.preds.append(pred)
+                self.trues.append(true)
+                self.tokens.append(token)
 
     def get_scores(self):
         """

--- a/pie/models/scorer.py
+++ b/pie/models/scorer.py
@@ -95,6 +95,7 @@ class Scorer(object):
 
         # compute scores for unknown input tokens
         unk_trues, unk_preds, amb_trues, amb_preds = [], [], [], []
+        unk_targ_trues, unk_targ_preds = [], []
         for true, pred, token in zip(self.trues, self.preds, self.tokens):
             if self.known_tokens and token not in self.known_tokens:
                 unk_trues.append(true)
@@ -102,6 +103,12 @@ class Scorer(object):
             if self.amb_tokens and token in self.amb_tokens:
                 amb_trues.append(true)
                 amb_preds.append(pred)
+            # token-level encoding doesn't have unknown targets (only OOV)
+            if self.label_encoder.known_tokens:
+                if true not in self.label_encoder.known_tokens:
+                    unk_targ_trues.append(true)
+                    unk_targ_preds.append(pred)
+
         support = len(unk_trues)
         if support > 0:
             output['unknown-tokens'] = compute_scores(unk_trues, unk_preds)
@@ -110,16 +117,9 @@ class Scorer(object):
             output['ambiguous-tokens'] = compute_scores(amb_trues, amb_preds)
 
         # compute scores for unknown targets
-        if self.label_encoder.known_tokens:
-            # token-level encoding doesn't have unknown targets (only OOV)
-            unk_trues, unk_preds = [], []
-            for true, pred in zip(self.trues, self.preds):
-                if true not in self.label_encoder.known_tokens:
-                    unk_trues.append(true)
-                    unk_preds.append(pred)
-            support = len(unk_trues)
-            if support > 0:
-                output['unknown-targets'] = compute_scores(unk_trues, unk_preds)
+        support = len(unk_targ_trues)
+        if support > 0:
+            output['unknown-targets'] = compute_scores(unk_targ_trues, unk_targ_preds)
 
         return output
 

--- a/pie/models/scorer.py
+++ b/pie/models/scorer.py
@@ -5,7 +5,7 @@ from termcolor import colored
 from terminaltables import github_table
 from collections import Counter, defaultdict
 
-from sklearn.metrics import precision_score, recall_score, accuracy_score
+from sklearn.metrics import accuracy_score, precision_recall_fscore_support
 from pie import utils
 from pie import constants
 
@@ -34,8 +34,9 @@ def compute_scores(trues, preds):
         return round(float(score), 4)
 
     with utils.shutup():
-        p = format_score(precision_score(trues, preds, average='macro'))
-        r = format_score(recall_score(trues, preds, average='macro'))
+        p, r, f1, _ = precision_recall_fscore_support(trues, preds, average="macro")
+        p = format_score(p)
+        r = format_score(r)
         a = format_score(accuracy_score(trues, preds))
 
     return {'accuracy': a, 'precision': p, 'recall': r, 'support': len(trues)}

--- a/pie/models/scorer.py
+++ b/pie/models/scorer.py
@@ -95,7 +95,7 @@ class Scorer(object):
 
         # compute scores for unknown input tokens
         unk_trues, unk_preds, amb_trues, amb_preds = [], [], [], []
-        unk_targ_trues, unk_targ_preds = [], []
+        unk_trg_trues, unk_trg_preds = [], []
         for true, pred, token in zip(self.trues, self.preds, self.tokens):
             if self.known_tokens and token not in self.known_tokens:
                 unk_trues.append(true)
@@ -106,8 +106,8 @@ class Scorer(object):
             # token-level encoding doesn't have unknown targets (only OOV)
             if self.label_encoder.known_tokens:
                 if true not in self.label_encoder.known_tokens:
-                    unk_targ_trues.append(true)
-                    unk_targ_preds.append(pred)
+                    unk_trg_trues.append(true)
+                    unk_trg_preds.append(pred)
 
         support = len(unk_trues)
         if support > 0:
@@ -117,9 +117,9 @@ class Scorer(object):
             output['ambiguous-tokens'] = compute_scores(amb_trues, amb_preds)
 
         # compute scores for unknown targets
-        support = len(unk_targ_trues)
+        support = len(unk_trg_trues)
         if support > 0:
-            output['unknown-targets'] = compute_scores(unk_targ_trues, unk_targ_preds)
+            output['unknown-targets'] = compute_scores(unk_trg_trues, unk_trg_preds)
 
         return output
 

--- a/pie/models/scorer.py
+++ b/pie/models/scorer.py
@@ -255,16 +255,25 @@ class Scorer(object):
 
         return '\n'.join(summary)
 
-    def print_summary(self, full=False, most_common=100, confusion_matrix=False):
+    def print_summary(self, full=False, most_common=100, confusion_matrix=False, scores=None):
         """
         Get evaluation summary
+
+        :param full: Get full report with error summary
+        :param confusion_matrix: Get a confusion matrix
+        :param most_common: Limit the full report to the number indicated
+        :param scores: If scores are already computed, get passed here
         """
+
         print()
         print("::: Evaluation report for task: {} :::".format(self.label_encoder.name))
         print()
 
+        if scores is None:
+            scores = self.get_scores()
+
         # print scores
-        print(yaml.dump(self.get_scores(), default_flow_style=False))
+        print(yaml.dump(scores, default_flow_style=False))
 
         if full:
             print()
@@ -276,3 +285,4 @@ class Scorer(object):
                 print(self.get_classification_summary(most_common=most_common))
         if confusion_matrix:
             print((github_table.GithubFlavoredMarkdownTable(self.get_confusion_matrix_table())).table)
+

--- a/pie/scripts/evaluate.py
+++ b/pie/scripts/evaluate.py
@@ -32,6 +32,14 @@ def run(model_path, test_path, train_path,
     if train_path:
         trainset = Dataset(
             settings, Reader(settings, train_path), model.label_encoder)
+    elif hasattr(settings, "input_path") and settings.input_path:
+        print("--- Using train set from settings")
+        trainset = Dataset(
+            settings, Reader(settings, settings.input_path), model.label_encoder)
+
+    if not len(test_path) and hasattr(settings, "test_path"):
+        print("--- Using test set from settings")
+        test_path = (settings.test_path, )
 
     testset = Dataset(settings, Reader(settings, *test_path), model.label_encoder)
 

--- a/pie/scripts/group.py
+++ b/pie/scripts/group.py
@@ -54,7 +54,7 @@ def tag_pipe(model_spec, device, batch_size, lower, beam_width, use_beam, tokeni
 @pie_cli.command("eval")
 @click.argument('model_path')
 @click.argument('test_path', nargs=-1)
-@click.argument('train_path')
+@click.option('--train_path', help="File used to compute unknown tokens/targets", default=None)
 @click.option('--settings', help="Settings file used for training")
 @click.option('--batch_size', type=int, default=500)
 @click.option('--buffer_size', type=int, default=100000)

--- a/pie/trainer.py
+++ b/pie/trainer.py
@@ -255,6 +255,8 @@ class Trainer(object):
 
         self.model.eval()
 
+        stored_scores = {}
+
         with torch.no_grad():
             dev_loss = self.evaluate(devset)
             print()
@@ -263,13 +265,14 @@ class Trainer(object):
             print('\n'.join('{}: {:.3f}'.format(k, v) for k, v in dev_loss.items()))
             print()
             summary = self.model.evaluate(devset, self.dataset)
-            for task in summary.values():
-                task.print_summary()
+            for task_name, scorer in summary.items():
+                stored_scores[task_name] = scorer.get_scores()
+                scorer.print_summary(scores=stored_scores[task_name])
 
         self.model.train()
         dev_scores = {}
-        for task, scorer in summary.items():
-            dev_scores[task] = scorer.get_scores()['all']['accuracy']
+        for task, scored in stored_scores.items():
+            dev_scores[task] = scored['all']['accuracy']
         # add lm scores
         if 'lm_fwd' in dev_loss or 'lm_bwd' in dev_loss:
             dev_scores['lm_fwd'] = dev_loss['lm_fwd']


### PR DESCRIPTION
This one possible improvement for #29.

Basically, in sklearn.metrics.classifications, both `precision_score` and `recall_score` are using `precision_recall_fscore_support`. This mean the function was used twice for the same result in 

https://github.com/emanjavacas/pie/blob/9fa672c04659b2c2219cb704027f48ba703c28b7/pie/models/scorer.py#L37-L38

PS: I added a change to the cli for evaluation because it was boring me to death to have to deal with this copy past everytime. Now `pie eval` loads path from `--settings` when none others are provided.