### PR TITLE
(TabReader) Fixed an issue where the TabReader would throw exception …

### DIFF
--- a/pie/data/tabreader.py
+++ b/pie/data/tabreader.py
@@ -109,16 +109,16 @@ class TabReader(BaseReader):
             for line_num, line in enumerate(f):
                 line = line.strip()
 
-                # break
+                # Empty line as chunk break
                 if not line and len(parser.inp) > 0:
+                        yield parser.inp, parser.tasks
+                        parser.reset()
+                        continue
+                # brealine configuration as chunk break
+                elif parser.check_breakline():
                     yield parser.inp, parser.tasks
                     parser.reset()
-                    continue
-
-                if parser.check_breakline():
-                    yield parser.inp, parser.tasks
-                    parser.reset()
-
+                # max size as chunk break
                 elif len(parser.inp) > self.max_sent_len:
                     inp = parser.inp[:self.max_sent_len]
                     tasks = {}
@@ -127,10 +127,11 @@ class TabReader(BaseReader):
                     yield inp, tasks
                     parser.reset(self.max_sent_len)
 
-                try:
-                    parser.add(line, line_num)
-                except LineParseException as e:
-                    yield e
+                if line:
+                    try:
+                        parser.add(line, line_num)
+                    except LineParseException as e:
+                        yield e
 
             if len(parser.inp) > 0:
                 yield parser.inp, parser.tasks

--- a/pie/scripts/train.py
+++ b/pie/scripts/train.py
@@ -2,9 +2,8 @@
 # Can be run with python -m pie.scripts.train
 import time
 import os
-import logging
 from datetime import datetime
-
+import logging
 
 import pie
 from pie.settings import settings_from_file
@@ -42,6 +41,8 @@ def run(config_path):
         torch.cuda.manual_seed(seed)
 
     settings = settings_from_file(config_path)
+    if settings.verbose:
+        logging.basicConfig(level=logging.INFO)
 
     # check settings
     # - check at least and at most one target


### PR DESCRIPTION
…on empty lines.

I had an issue with datasets where empty lines are used for breaking chunks, and potentially real errors would get in the whole set of errors. These `if` statements should clear the issue.