### PR TITLE
Scorer/Trainer now use scanning of trainset only once for all epochs/…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # When flask is installed, produce a flask binary file
 flask
+# Tired of ignoring it
+.idea 
 # If one of these kind of file should be added, then it should be force added.
 #   Otherwise, it allows for clean development.
 *.csv

--- a/pie/models/scorer.py
+++ b/pie/models/scorer.py
@@ -12,22 +12,30 @@ from pie import utils
 from pie import constants
 
 
-def get_ambiguous_tokens(trainset, label_encoder):
-    ambs = defaultdict(Counter)
-    for _, (inp, tasks) in trainset.reader.readsents():
-        trues = label_encoder.preprocess(tasks[label_encoder.target], inp)
-        for tok, true in zip(inp, trues):
-            ambs[tok][true] += 1
+def get_known_and_ambigous_tokens(trainset, label_encoders):
+    """ Retrieve known and ambiguous token for all label encoders, for one dataset
 
-    return set(tok for tok in ambs if len(ambs[tok]) > 1)
-
-
-def get_known_tokens(trainset):
+    :param trainset: Trainset
+    :param label_encoders: List of label encoders
+    :return: Known set of tokens, ambiguous token par task (Dict[task, Set[str])
+    """
     known = set()
-    for _, (inp, _) in trainset.reader.readsents():
-        for tok in inp:
+    ambs = defaultdict(lambda: defaultdict(Counter))
+    order_label = [label.target for label in label_encoders]
+    for _, (inp, tasks) in trainset.reader.readsents():
+        task_trues = [
+            label.preprocess(tasks[label.target], inp)
+            for label in label_encoders
+        ]
+        for tok, task_true in zip(inp, zip(*task_trues)):
+            for task, true in zip(order_label, task_true):
+                ambs[task][tok][true] += 1
             known.add(tok)
-    return known
+    return known, {task: set(
+        tok
+        for tok in ambs[task] if len(ambs[task][tok]) > 1)
+        for task in ambs
+    }
 
 
 def compute_scores(trues, preds):
@@ -48,15 +56,17 @@ class Scorer(object):
     """
     Accumulate predictions over batches and compute evaluation scores
     """
-    def __init__(self, label_encoder, trainset=None):
+    def __init__(self, label_encoder):
         self.label_encoder = label_encoder
         self.known_tokens = self.amb_tokens = None
-        if trainset:
-            self.known_tokens = get_known_tokens(trainset)
-            self.amb_tokens = get_ambiguous_tokens(trainset, label_encoder)
         self.preds = []
         self.trues = []
         self.tokens = []
+
+    def set_known_and_amb(self, known_tokens, amb_tokens):
+        """ Set known tokens as well as ambiguous tokens """
+        self.known_tokens = known_tokens
+        self.amb_tokens = amb_tokens
 
     def serialize_preds(self, path):
         """

--- a/pie/trainer.py
+++ b/pie/trainer.py
@@ -325,7 +325,10 @@ class Trainer(object):
 
             if self.check_freq > 0 and b > 0 and b % self.check_freq == 0:
                 if devset is not None:
+                    rep_start = time.time()
                     scores = self.run_check(devset)
+                    logging.info("Evaluation time: {} sec".format(time.time() - rep_start))
+                    rep_start = time.time()
 
         return scores
 


### PR DESCRIPTION
…tasks

Fixed #48

BaseModel keeps now in memory (!= GPU memory) the unknown and the ambiguous tokens per task.
This solves a bug where per `run_check`, the train set would be read + preprocessed + analyzed `n_task x 2` where 2 is ambigous and known reading.
Eg. on a 1.7M tokens trainset with 11 tasks, and 10k tokens in dev, we have:

Before fix: ~ 360 sec / run_check / epoch
After_fix:
  - 1st epoch: 35 sec
  - subsequent: ~10 sec

Added logging of evaluation time to keep track of potential improvement down the line

I'll probably ask for a release bump after this bug fix :D