### PR TITLE
(Bugfix) Make default temp dir for training OS related using Python …

### DIFF
--- a/pie/trainer.py
+++ b/pie/trainer.py
@@ -5,6 +5,8 @@ import logging
 import time
 import collections
 import random
+import tempfile
+
 
 import tqdm
 
@@ -79,7 +81,7 @@ class TaskScheduler(object):
         self.factor = settings.factor
         self.threshold = settings.threshold
         self.min_weight = settings.min_weight
-        self.fid = '/tmp/{}'.format(str(uuid.uuid1()))
+        self.fid = os.path.join(tempfile.gettempdir(), str(uuid.uuid1()))
 
     def __repr__(self):
         # task scheduler

--- a/pie/utils.py
+++ b/pie/utils.py
@@ -14,6 +14,10 @@ import functools
 import unicodedata
 from contextlib import contextmanager
 from subprocess import check_output, CalledProcessError
+import tempfile
+
+
+DEFAULT_TEMP_DIR = tempfile.gettempdir()
 
 
 def lower_str(s):
@@ -165,7 +169,7 @@ def shutup():
 
 
 @contextmanager
-def tmpfile(parent='/tmp/'):
+def tmpfile(parent=DEFAULT_TEMP_DIR):
     fid = str(uuid.uuid1())
     tmppath = os.path.join(parent, fid)
     yield tmppath


### PR DESCRIPTION
…tempfile module

Allows for (potentially) training on Windows by moving to C:\TEMP instead of /tmp/