### PR TITLE
Feature/shared encoder for input

### DIFF
--- a/pie/data/__init__.py
+++ b/pie/data/__init__.py
@@ -1,5 +1,5 @@
 
-from .dataset import LabelEncoder, MultiLabelEncoder, Dataset, Tasks
+from .dataset import LabelEncoder, MultiLabelEncoder, Dataset, Tasks, IncompatibleEncoders
 from .dataset import pack_batch, device_wrapper
 from .reader import Reader, TokenIterator
 from . import preprocessors

--- a/pie/data/__init__.py
+++ b/pie/data/__init__.py
@@ -1,5 +1,5 @@
 
-from .dataset import LabelEncoder, MultiLabelEncoder, Dataset
+from .dataset import LabelEncoder, MultiLabelEncoder, Dataset, Tasks
 from .dataset import pack_batch, device_wrapper
 from .reader import Reader, TokenIterator
 from . import preprocessors

--- a/pie/data/dataset.py
+++ b/pie/data/dataset.py
@@ -378,12 +378,12 @@ class MultiLabelEncoder(object):
 
         Encoders are merged only if they translation keys are the same (translation values are not checked)"""
         if not self.char.is_compatible(other.char):
-            raise IncompatibleEncoders("Character Encoder or settings are different for char encoders")
+            raise IncompatibleEncoders("Input character encoder map or settings are incompatible with current dataset")
         else:
             self.char = other.char
         if use_wemb:
             if not self.word.is_compatible(other.word):
-                raise IncompatibleEncoders("Word Encoder or settings are different for char encoders")
+                raise IncompatibleEncoders("Input word encoder map or settings are incompatible with current dataset")
             else:
                 self.word = other.word
 

--- a/pie/default_settings.json
+++ b/pie/default_settings.json
@@ -22,6 +22,8 @@
   "word_max_size": 20000, // maximum vocabulary size for input word embeddings
   "word_min_freq": 1, // min freq of a word to be part of the vocabulary
   // (only used if word_max_size is 0)
+  "share_input_encoder": false, // If set, path to a model whose encoder will be reused
+  // Recommended for multi model / multi tasks training on the same corpus
   "word_lower": false, // whether to lowercase input tokens
   "char_max_size": 500, // maximum vocabulary size for input character embeddings
   "char_min_freq": 1, // min freq of a character to be part of the vocabulary

--- a/pie/scripts/train.py
+++ b/pie/scripts/train.py
@@ -63,6 +63,13 @@ def run(settings):
         print()
     label_encoder.fit_reader(reader)
 
+    if settings.share_input_encoder:
+        src = SimpleModel.load(settings.share_input_encoder)
+        label_encoder.merge_input_encoder(
+            src.label_encoder,
+            use_wemb=settings.wemb_dim > 0
+        )
+
     if settings.verbose:
         print()
         print("::: Vocabulary :::")

--- a/pie/scripts/train.py
+++ b/pie/scripts/train.py
@@ -64,9 +64,9 @@ def run(settings):
     label_encoder.fit_reader(reader)
 
     if settings.share_input_encoder:
-        src = SimpleModel.load(settings.share_input_encoder)
+        print("::: Reusing input encoder from {} :::".format(settings.share_input_encoder))
         label_encoder.merge_input_encoder(
-            src.label_encoder,
+            SimpleModel.load(settings.share_input_encoder).label_encoder,
             use_wemb=settings.wemb_dim > 0
         )
 

--- a/test/data/test_data.py
+++ b/test/data/test_data.py
@@ -2,7 +2,7 @@
 import os
 import unittest
 
-from pie.data import Dataset, Reader, MultiLabelEncoder
+from pie.data import Dataset, Reader, MultiLabelEncoder, IncompatibleEncoders
 from pie.settings import settings_from_file
 
 
@@ -65,81 +65,126 @@ class TestWordCharEncoding(unittest.TestCase):
                 total_words += nwords
             self.assertEqual(idx, total_words, "Checked all words")
 
-    def test_MultiLabelEncoder_Grouping(self):
+
+class TestMerginEncoders(unittest.TestCase):
+    def setUp(self):
         sentence_a = [["A", "B", "C"]]
         sentence_b = [["B", "B", "C"]]
         sentence_c = [["B", "B", "C"]]
         sentence_d = [["AB", "A", "C"]]
+        sentence_e = [["BBB", "A", "C"]]
 
-        encoder_a_1 = (("task1", ), MultiLabelEncoder())
-        encoder_a_2 = (("task2", ), MultiLabelEncoder())
-        encoder_b_1 = (("task3", ), MultiLabelEncoder())
-        encoder_c_1 = (("task4", "task5"), MultiLabelEncoder(char_lower=True))
-        encoder_d_1 = (("task6", ), MultiLabelEncoder())
+        self.encoder_a_1 = (("task1",), MultiLabelEncoder())
+        self.encoder_a_2 = (("task2",), MultiLabelEncoder())
+        self.encoder_b_1 = (("task3",), MultiLabelEncoder())
+        self.encoder_c_1 = (("task4", "task5"), MultiLabelEncoder(char_lower=True))
+        self.encoder_d_1 = (("task6",), MultiLabelEncoder())
+        self.encoder_e_1 = (("task7",), MultiLabelEncoder())
 
-        encoder_a_1[1].fit(sentence_a)
-        encoder_a_2[1].fit(sentence_a)
-        encoder_b_1[1].fit(sentence_b)
-        encoder_c_1[1].fit(sentence_c)
-        encoder_d_1[1].fit(sentence_d)
+        self.encoder_a_1[1].fit(sentence_a)
+        self.encoder_a_2[1].fit(sentence_a)
+        self.encoder_b_1[1].fit(sentence_b)
+        self.encoder_c_1[1].fit(sentence_c)
+        self.encoder_d_1[1].fit(sentence_d)
+        self.encoder_e_1[1].fit(sentence_e)
 
-        self.assertEqual(encoder_a_1[1], encoder_a_2[1], "Check that the premises of equality are right")
-        self.assertNotEqual(encoder_a_1[1], encoder_b_1[1], "Check that the premises of equality are right")
-        self.assertNotEqual(encoder_b_1[1], encoder_c_1[1], "Check that the premises of equality are right")
-        self.assertNotEqual(encoder_a_1[1], encoder_d_1[1], "Check that the premises of equality are right")
+    def test_MultiLabelEncoder_grouping(self):
+        self.assertEqual(self.encoder_a_1[1], self.encoder_a_2[1], "Check that the premises of equality are right")
+        self.assertNotEqual(self.encoder_a_1[1], self.encoder_b_1[1], "Check that the premises of equality are right")
+        self.assertNotEqual(self.encoder_b_1[1], self.encoder_c_1[1], "Check that the premises of equality are right")
+        self.assertNotEqual(self.encoder_a_1[1], self.encoder_d_1[1], "Check that the premises of equality are right")
 
         packed = MultiLabelEncoder.group_input_encoders([
-            encoder_a_1,
-            encoder_a_2,
-            encoder_b_1,
-            encoder_c_1
+            self.encoder_a_1,
+            self.encoder_a_2,
+            self.encoder_b_1,
+            self.encoder_c_1
         ])
 
         self.assertEqual(
             packed,
             [
-                ([("task1", ), ("task2", )], encoder_a_1[1]),
-                ([("task3", )], encoder_b_1[1]),
-                ([("task4", "task5", )], encoder_c_1[1])
+                ([("task1",), ("task2",)], self.encoder_a_1[1]),
+                ([("task3",)], self.encoder_b_1[1]),
+                ([("task4", "task5",)], self.encoder_c_1[1])
             ],
             "Grouping encoders should allow for deduplicating encoding"
         )
 
         packed = MultiLabelEncoder.group_input_encoders([
-            encoder_a_1,
-            encoder_a_2,
-            encoder_b_1,
-            encoder_c_1,
-            encoder_d_1
+            self.encoder_a_1,
+            self.encoder_a_2,
+            self.encoder_b_1,
+            self.encoder_c_1,
+            self.encoder_d_1
         ])
 
         self.assertEqual(
             packed,
             [
-                ([("task1", ), ("task2", )], encoder_a_1[1]),
-                ([("task3", )], encoder_b_1[1]),
-                ([("task4", "task5", )], encoder_c_1[1]),
-                ([("task6", )], encoder_d_1[1])
+                ([("task1",), ("task2",)], self.encoder_a_1[1]),
+                ([("task3",)], self.encoder_b_1[1]),
+                ([("task4", "task5",)], self.encoder_c_1[1]),
+                ([("task6",)], self.encoder_d_1[1])
             ],
             "Grouping encoders should allow for deduplicating encoding: chars and words should matter"
         )
 
         packed = MultiLabelEncoder.group_input_encoders([
-            encoder_a_1,
-            encoder_a_2,
-            encoder_b_1,
-            encoder_c_1,
-            encoder_d_1
-        ], check_attribs=("char", ))
+            self.encoder_a_1,
+            self.encoder_a_2,
+            self.encoder_b_1,
+            self.encoder_c_1,
+            self.encoder_d_1
+        ], check_attribs=("char",))
 
         self.assertEqual(
             packed,
             [
-                ([("task1", ), ("task2", ), ("task6", )], encoder_a_1[1]),
-                ([("task3", )], encoder_b_1[1]),
-                ([("task4", "task5", )], encoder_c_1[1])
+                ([("task1",), ("task2",), ("task6",)], self.encoder_a_1[1]),
+                ([("task3",)], self.encoder_b_1[1]),
+                ([("task4", "task5",)], self.encoder_c_1[1])
             ],
             "Grouping encoders should allow for deduplicating encoding: only given attrib should matter"
+        )
+
+    def test_encoder_compatibility(self):
+        self.assertTrue(self.encoder_a_1[1].char.is_compatible(self.encoder_a_1[1].char))
+        self.assertFalse(self.encoder_a_1[1].char.is_compatible(self.encoder_b_1[1].char))
+
+        # E and A1 are compatible but not equal (same characters but different frequencies
+        #   hence different idx
+        self.assertTrue(self.encoder_a_1[1].char.is_compatible(self.encoder_e_1[1].char))
+        self.assertFalse(self.encoder_a_1[1].char == self.encoder_e_1[1].char)
+
+    def test_encoder_merging(self):
+        """ Ensure merging is prevented when needed """
+        # Words Encoder should prevent merging
+        with self.assertRaises(IncompatibleEncoders):
+            self.encoder_a_1[1].merge_input_encoder(
+                self.encoder_e_1[1]
+            )
+        # Char encoder should prevent merging when they are not equal
+        with self.assertRaises(IncompatibleEncoders):
+            self.encoder_a_1[1].merge_input_encoder(
+                self.encoder_b_1[1]
+            )
+        # Char encoder should prevent merging when they are not equal even ignoring wemb
+        with self.assertRaises(IncompatibleEncoders):
+            self.encoder_a_1[1].merge_input_encoder(
+                self.encoder_b_1[1],
+                use_wemb=False
+            )
+
+        # However, it should not prevent merging
+        self.encoder_a_1[1].merge_input_encoder(
+            self.encoder_e_1[1], use_wemb=False
+        )
+
+        # Merging should be effective
+        self.assertEqual(
+            self.encoder_a_1[1].char,
+            self.encoder_e_1[1].char
         )
 
 


### PR DESCRIPTION
Proposal for fixing #70 

It's unittested which seemed to be the best way to check things out. Only the tagging/training is not unittested.

I did not give the option to force reusing (and not caring about new characters...), maybe this is a feature you think could be useful ? (training on two different dataset one smaller than the other ?)