### PR TITLE
Feature: allow picking whatever pytorch lr_scheduler

### DIFF
--- a/pie/default_settings.json
+++ b/pie/default_settings.json
@@ -124,10 +124,16 @@
   "optimizer": "Adam", // optimizer type
   "clip_norm": 5.0, // clip norm of gradient up to this value
   "lr": 0.001,
-  "lr_factor": 0.75, // lr schedule (decrease lr by this factor after `lr_patience` epochs
-  // without improvement on dev-set data)
-  "min_lr": 0.000001, // minimum learning rate
-  "lr_patience": 2, // patience for lr schedule
+
+  "lr_scheduler": "ReduceLROnPlateau",
+  "lr_scheduler_params": {
+    // needs to be adapted if lr_scheduler is not ReduceLROnPlateau
+    "mode": "max",
+    "factor": 0.75,
+    "patience": 2,
+    "min_lr": 0.000001
+  },
+
   "checks_per_epoch": 1, // check model on dev-set so many times during epoch
 
   // * Model hyperparameters

--- a/pie/default_settings.json
+++ b/pie/default_settings.json
@@ -126,6 +126,7 @@
   "lr": 0.001,
 
   "lr_scheduler": "ReduceLROnPlateau",
+  "lr_scheduler_delay": 0, // Number of steps without using the lr_scheduler
   "lr_scheduler_params": {
     // needs to be adapted if lr_scheduler is not ReduceLROnPlateau
     "mode": "max",

--- a/pie/settings.py
+++ b/pie/settings.py
@@ -106,6 +106,12 @@ def check_settings(settings):
     if not has_target:
         raise ValueError("Needs at least one target task")
 
+    # backward compatibility
+    if "lr_patience" in settings:
+        settings.lr_scheduler_params['patience'] = settings.lr_patience
+    if "lr_factor" in settings:
+        settings.lr_scheduler_params['factor'] = settings.lr_factor
+
     return settings
 
 

--- a/pie/trainer.py
+++ b/pie/trainer.py
@@ -150,20 +150,30 @@ class TaskScheduler(object):
 
 
 class LRScheduler(object):
-    def __init__(self, optimizer, lr_scheduler='ReduceLROnPlateau', **kwargs)
+    def __init__(self, optimizer, lr_scheduler='ReduceLROnPlateau', delay=0, **kwargs):
+        self.nb_steps: int = 0
+        self.delay: int = delay
         self.lr_scheduler = getattr(optim.lr_scheduler, lr_scheduler)(
             optimizer, **kwargs)
 
     def step(self, score):
+        self.nb_steps += 1
+
+        # If we have a delay, we do not apply the step() method of the lr_scheduler until it's reached
+        if self.delay and self.nb_steps <= self.delay:
+            return
+
         if isinstance(self.lr_scheduler, optim.lr_scheduler.ReduceLROnPlateau):
             self.lr_scheduler.step(score)
         else:
-            slef.lr_scheduler.step()
+            self.lr_scheduler.step()
 
     def __repr__(self):
-        res = '<LrScheduler="{}" lr="{:g}"'.format(
+        res = '<LrScheduler="{}" lr="{:g}" delay="{}" steps="{}"'.format(
             self.lr_scheduler.__class__.__name__,
-            self.lr_scheduler.optimizer.param_groups[0]['lr'])
+            self.lr_scheduler.optimizer.param_groups[0]['lr'],
+            self.delay,
+            self.nb_steps)
         for key in dir(self.lr_scheduler):
             val = getattr(self.lr_scheduler, key)
             if (not key.startswith('__')) and isinstance(val, (str, float, int)):
@@ -207,7 +217,11 @@ class Trainer(object):
 
         self.task_scheduler = TaskScheduler(settings)
         self.lr_scheduler = LRScheduler(
-            self.optimizer, settings.lr_scheduler, **settings.lr_scheduler_params)
+            self.optimizer,
+            lr_scheduler=settings.lr_scheduler,
+            delay=settings.lr_scheduler_delay,
+            **settings.lr_scheduler_params
+        )
 
         if settings.verbose:
             print()

--- a/pie/trainer.py
+++ b/pie/trainer.py
@@ -161,7 +161,8 @@ class LRScheduler(object):
             slef.lr_scheduler.step()
 
     def __repr__(self):
-        res = '<LrScheduler lr="{:g}"'.format(
+        res = '<LrScheduler="{}" lr="{:g}"'.format(
+            self.lr_scheduler.__class__.__name__,
             self.lr_scheduler.optimizer.param_groups[0]['lr'])
         for key in dir(self.lr_scheduler):
             val = getattr(self.lr_scheduler, key)


### PR DESCRIPTION
Here is a draft for the lr_scheduler params (related to #78) and how to avoid breaking backwards compatibility. Could you use it to test the results of the cosineannealing that you got? 