### PR TITLE
Feature/allow picking lr scheduler

### DIFF
--- a/pie/default_settings.json
+++ b/pie/default_settings.json
@@ -126,6 +126,7 @@
   "lr": 0.001,
 
   "lr_scheduler": "ReduceLROnPlateau",
+  "lr_scheduler_delay": 0, // Number of steps without using the lr_scheduler
   "lr_scheduler_params": {
     // needs to be adapted if lr_scheduler is not ReduceLROnPlateau
     "mode": "max",

--- a/pie/trainer.py
+++ b/pie/trainer.py
@@ -150,7 +150,7 @@ class TaskScheduler(object):
 
 
 class LRScheduler(object):
-    def __init__(self, optimizer, lr_scheduler='ReduceLROnPlateau', **kwargs)
+    def __init__(self, optimizer, lr_scheduler='ReduceLROnPlateau', **kwargs):
         self.lr_scheduler = getattr(optim.lr_scheduler, lr_scheduler)(
             optimizer, **kwargs)
 
@@ -158,7 +158,7 @@ class LRScheduler(object):
         if isinstance(self.lr_scheduler, optim.lr_scheduler.ReduceLROnPlateau):
             self.lr_scheduler.step(score)
         else:
-            slef.lr_scheduler.step()
+            self.lr_scheduler.step()
 
     def __repr__(self):
         res = '<LrScheduler="{}" lr="{:g}"'.format(


### PR DESCRIPTION
Fixed two small typos and added support for delay.
The current version of `lr_scheduler_params` is not working with other `Scheduler`, because settings merge the Defaults and it results in passing keywords such as `mode` to `CosineAnnealing`.