### PR TITLE
Fix a bug where pack_padded_sequence would take a cuda tensor instead of a CPU one

### DIFF
--- a/pie/models/embedding.py
+++ b/pie/models/embedding.py
@@ -115,7 +115,7 @@ class RNNEmbedding(nn.Module):
         char, nchars = char[:, sort], nchars[sort]
         if isinstance(self.rnn, nn.RNNBase):
             outs, emb = self.rnn(
-                nn.utils.rnn.pack_padded_sequence(char, nchars), hidden)
+                nn.utils.rnn.pack_padded_sequence(char, nchars.cpu()), hidden)
             outs, _ = nn.utils.rnn.pad_packed_sequence(outs)
             if isinstance(emb, tuple):
                 emb, _ = emb

--- a/pie/models/encoder.py
+++ b/pie/models/encoder.py
@@ -38,7 +38,7 @@ class RNNEncoder(nn.Module):
 
         _, sort = torch.sort(lengths, descending=True)
         _, unsort = sort.sort()
-        inp = nn.utils.rnn.pack_padded_sequence(inp[:, sort], lengths[sort])
+        inp = nn.utils.rnn.pack_padded_sequence(inp[:, sort], lengths[sort].cpu())
         outs, hiddens = [], []
 
         for layer, rnn in enumerate(self.rnn):
@@ -46,7 +46,7 @@ class RNNEncoder(nn.Module):
             if layer > 0:
                 inp, lengths = nn.utils.rnn.pad_packed_sequence(inp)
                 inp = torch_utils.sequential_dropout(inp, self.dropout, self.training)
-                inp = nn.utils.rnn.pack_padded_sequence(inp, lengths)
+                inp = nn.utils.rnn.pack_padded_sequence(inp, lengths.cpu())
             # run layer
             louts, lhidden = rnn(inp, hidden[layer])
             # unpack

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ DESCRIPTION = 'A Framework for Joint Learning of Sequence Labeling Tasks'
 URL = 'https://github.com/emanjavacas/pie'
 AUTHOR = 'Enrique Manjavacas; Mike Kestemont; Thibault Clerice'
 REQUIRES_PYTHON = '>=3.6.0'
-VERSION = "0.3.7b"
+VERSION = "0.3.7c"
 
 # What packages are required for this module to be executed?
 


### PR DESCRIPTION
Of course there had to be a regression / change I did not catch in my different tests.
So here you go: `pack_added_sequence` requires a CPU tensor no instead of a cuda one.