### PR TITLE
Fixed AttentionalDecoder truncating to 20 chars

### DIFF
--- a/pie/models/decoder.py
+++ b/pie/models/decoder.py
@@ -315,8 +315,7 @@ class AttentionalDecoder(nn.Module):
         return loss
 
     def predict_max(self, enc_outs, lengths,
-                    max_seq_len=20, bos=None, eos=None,
-                    context=None):
+                    bos=None, eos=None, context=None):
         """
         Decoding routine for inference with step-wise argmax procedure
 
@@ -331,6 +330,8 @@ class AttentionalDecoder(nn.Module):
         mask = torch.ones(batch, dtype=torch.int64, device=device)
         inp = torch.zeros(batch, dtype=torch.int64, device=device) + bos
         hyps, scores = [], 0
+        # Take the longest known token as the maximum sequence length.
+        max_seq_len = len(max(self.label_encoder.known_tokens, key=len))
 
         for _ in range(max_seq_len):
             if mask.sum().item() == 0:


### PR DESCRIPTION
When labels for a task are longer than 20 characters, they would be decoded as truncated to 20 characters. So instead we first look at the length of the longest known token.

Before this fix, we would get extremely low test scores for datasets with e.g. long part of speech tags: after all, truncated labels don't match the original ones.

#73 / #74 almost completely rewrites `AttentionalDecoder.predict_max()` for a speed up. However, it still contains the same bug mentioned here. Notably, our fix here **greatly slows down** `predict_max()` for long labels. For example, I went from 2min44s to 11m00s trying to evaluate the same set & model before and after this fix. 

Therefore, I'm pinging @PonteIneptique as well, as I'm not sure how this fix would work in the improved `predict_max()`.

Naively inserting the fix at [line 344](https://github.com/emanjavacas/pie/blob/a311807c627d53ce1260c5e3ac99d7c7e479876e/pie/models/decoder.py#L344) and removing [line 424](https://github.com/emanjavacas/pie/blob/a311807c627d53ce1260c5e3ac99d7c7e479876e/pie/models/decoder.py#L424) throws an error:

```
Traceback (most recent call last):
  File "/pie/pie/evaluate.py", line 84, in <module>
    run(model_path=args.model_path, test_path=args.test_path,
  File "/pie/pie/evaluate.py", line 56, in run
    for task in model.evaluate(testset, trainset,
  File "/pie/pie/pie/models/base_model.py", line 83, in evaluate
    preds = self.predict(inp, **kwargs)
  File "/pie/pie/pie/models/model.py", line 314, in predict
    hyps, prob = decoder.predict_max(
  File "/pie/pie/pie/models/decoder.py", line 362, in predict_max
    outs, _ = self.attn(outs, enc_outs, lengths)
  File "/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/pie/pie/pie/models/attention.py", line 164, in forward
    mask = mask.unsqueeze(0).expand_as(weights)
RuntimeError: The expanded size of the tensor (20) must match the existing size (43) at non-singleton dimension 2.  Target sizes: [1, 12576, 20].  Tensor sizes: [1, 12576, 43]
```
